### PR TITLE
refactor code to improve code quality

### DIFF
--- a/SoluiNet.DevTools.Core.UI.WPF/Tools/Image/ImageHelper.cs
+++ b/SoluiNet.DevTools.Core.UI.WPF/Tools/Image/ImageHelper.cs
@@ -27,6 +27,11 @@ namespace SoluiNet.DevTools.Core.UI.WPF.Tools.Image
         /// <returns>Returns a bitmap image object.</returns>
         public static BitmapImage BitmapToImageSource(Bitmap bitmap)
         {
+            if (bitmap == null)
+            {
+                throw new ArgumentNullException(nameof(bitmap));
+            }
+
             using (MemoryStream memory = new MemoryStream())
             {
                 bitmap.Save(memory, System.Drawing.Imaging.ImageFormat.Bmp);

--- a/SoluiNet.DevTools.Core.UI.WPF/UIElement/ExtendedButton.cs
+++ b/SoluiNet.DevTools.Core.UI.WPF/UIElement/ExtendedButton.cs
@@ -196,6 +196,7 @@ namespace SoluiNet.DevTools.Core.UI.WPF.UIElement
         /// <summary>
         /// Render the button.
         /// </summary>
+        /// <param name="drawingContext">The drawing context.</param>
         protected override void OnRender(DrawingContext drawingContext)
         {
             base.OnRender(drawingContext);

--- a/SoluiNet.DevTools.Core.UI.WPF/UIElement/TwoActionButton.xaml.cs
+++ b/SoluiNet.DevTools.Core.UI.WPF/UIElement/TwoActionButton.xaml.cs
@@ -27,7 +27,7 @@ namespace SoluiNet.DevTools.Core.UI.WPF.UIElement
     /// </summary>
     public partial class TwoActionButton : UserControl
     {
-        private bool hasEnteredUserControl = false;
+        private bool hasEnteredUserControl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TwoActionButton"/> class.

--- a/SoluiNet.DevTools.Core.Web/Application/WebApplication.cs
+++ b/SoluiNet.DevTools.Core.Web/Application/WebApplication.cs
@@ -7,6 +7,7 @@ namespace SoluiNet.DevTools.Core.Web.Application
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -52,7 +53,7 @@ namespace SoluiNet.DevTools.Core.Web.Application
                 {
                     Debug.WriteLine(JsonTools.Serialize(exception));
 
-                    this.Logger.Debug(exception, string.Format("Couldn't load assembly '{0}'", dllFile));
+                    this.Logger.Debug(exception, string.Format(CultureInfo.InvariantCulture, "Couldn't load assembly '{0}'", dllFile));
                 }
             }
 
@@ -127,12 +128,12 @@ namespace SoluiNet.DevTools.Core.Web.Application
 
                 if (!enabledPlugins.ContainsKey(assemblyName) || !enabledPlugins[assemblyName])
                 {
-                    this.Logger.Info(string.Format("Found plugin '{0}' but it will be ignored because it isn't configured as enabled plugin.", assemblyName));
+                    this.Logger.Info(string.Format(CultureInfo.InvariantCulture, "Found plugin '{0}' but it will be ignored because it isn't configured as enabled plugin.", assemblyName));
 
                     continue;
                 }
 
-                this.Logger.Info(string.Format("Load plugin '{0}'.", assemblyName));
+                this.Logger.Info(string.Format(CultureInfo.InvariantCulture, "Load plugin '{0}'.", assemblyName));
 
                 if (type.Value.Contains("PluginDev"))
                 {
@@ -163,13 +164,13 @@ namespace SoluiNet.DevTools.Core.Web.Application
         }
 
         /// <inheritdoc/>
-        public ICollection<IProvidesWebCommunication> WebPlugins { get; set; }
+        public ICollection<IProvidesWebCommunication> WebPlugins { get; private set; }
 
         /// <inheritdoc/>
-        public ICollection<IBasePlugin> Plugins { get; set; }
+        public ICollection<IBasePlugin> Plugins { get; private set; }
 
         /// <inheritdoc/>
-        public ICollection<IRunsBackgroundTask> BackgroundTaskPlugins { get; set; }
+        public ICollection<IRunsBackgroundTask> BackgroundTaskPlugins { get; private set; }
 
         private Logger Logger
         {

--- a/SoluiNet.DevTools.Core.Web/Application/WebApplication.cs
+++ b/SoluiNet.DevTools.Core.Web/Application/WebApplication.cs
@@ -164,13 +164,13 @@ namespace SoluiNet.DevTools.Core.Web.Application
         }
 
         /// <inheritdoc/>
-        public ICollection<IProvidesWebCommunication> WebPlugins { get; private set; }
+        public ICollection<IProvidesWebCommunication> WebPlugins { get; set; }
 
         /// <inheritdoc/>
-        public ICollection<IBasePlugin> Plugins { get; private set; }
+        public ICollection<IBasePlugin> Plugins { get; set; }
 
         /// <inheritdoc/>
-        public ICollection<IRunsBackgroundTask> BackgroundTaskPlugins { get; private set; }
+        public ICollection<IRunsBackgroundTask> BackgroundTaskPlugins { get; set; }
 
         private Logger Logger
         {

--- a/SoluiNet.DevTools.Core/Tools/Database/DbHelper.cs
+++ b/SoluiNet.DevTools.Core/Tools/Database/DbHelper.cs
@@ -119,7 +119,7 @@ namespace SoluiNet.DevTools.Core.Tools.Database
         /// <returns>Returns a <see cref="List{DataTable}"/> with the results of the SQL command.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "All exceptions should be catched and written to log")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "'environment' parameter has been added for future implementations")]
-        public static List<DataTable> ExecuteSqlScript<TConnection, TCommand>(string connectionString, string sqlCommand, string environment = "Default")
+        public static IList<DataTable> ExecuteSqlScript<TConnection, TCommand>(string connectionString, string sqlCommand, string environment = "Default")
            where TConnection : IDbConnection
            where TCommand : IDbCommand
         {
@@ -278,7 +278,7 @@ namespace SoluiNet.DevTools.Core.Tools.Database
         /// <param name="sqlCommand">The SQL command.</param>
         /// <param name="environment">The environment on which the SQL command should be executed. If not provided it will default to "Default".</param>
         /// <returns>Returns a <see cref="List{DataTable}"/> with the results of the SQL command.</returns>
-        public static List<DataTable> ExecuteSqlServerScript(string connectionString, string sqlCommand, string environment = "Default")
+        public static IList<DataTable> ExecuteSqlServerScript(string connectionString, string sqlCommand, string environment = "Default")
         {
             return ExecuteSqlScript<SqlConnection, SqlCommand>(connectionString, sqlCommand, environment);
         }
@@ -314,7 +314,7 @@ namespace SoluiNet.DevTools.Core.Tools.Database
         /// <param name="impersonation">The impersonation which can be used for executing the SQL script.</param>
         /// <returns>Returns a <see cref="List{DataTable}"/> with the results of the SQL command. If provider type isn't supported it returns null.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "'impersonation' parameter has been added for future implementations")]
-        public static List<DataTable> ExecuteSqlScript(string providerType, string connectionString, string sqlCommand, string environment = "Default", WindowsImpersonationContext impersonation = null)
+        public static IList<DataTable> ExecuteSqlScript(string providerType, string connectionString, string sqlCommand, string environment = "Default", WindowsImpersonationContext impersonation = null)
         {
             switch (providerType)
             {

--- a/SoluiNet.DevTools.Core/Tools/Plugin/PluginHelper.cs
+++ b/SoluiNet.DevTools.Core/Tools/Plugin/PluginHelper.cs
@@ -329,7 +329,7 @@ namespace SoluiNet.DevTools.Core.Tools
         /// </summary>
         /// <param name="plugin">The plugin.</param>
         /// <returns>Returns a <see cref="List{T}"/> of all available environments for the overgiven plugin.</returns>
-        public static List<string> GetEnvironments(IProvidesDatabaseConnectivity plugin)
+        public static IList<string> GetEnvironments(IProvidesDatabaseConnectivity plugin)
         {
             var environmentList = new List<string>();
 
@@ -350,6 +350,11 @@ namespace SoluiNet.DevTools.Core.Tools
         /// <returns>Returns an instance of <see cref="Assembly"/> which contains the assembly for which the event was looking for.</returns>
         public static Assembly LoadAssembly(object sender, ResolveEventArgs args)
         {
+            if (sender == null)
+            {
+                throw new ArgumentNullException(nameof(sender));
+            }
+
             if (args == null)
             {
                 throw new ArgumentNullException(nameof(args));
@@ -389,7 +394,7 @@ namespace SoluiNet.DevTools.Core.Tools
         /// </summary>
         /// <typeparam name="T">The plugin type.</typeparam>
         /// <returns>Returns a <see cref="List{T}"/> of all available plugins which are castable to the overgiven plugin type.</returns>
-        public static List<T> GetPlugins<T>()
+        public static IList<T> GetPlugins<T>()
         {
             string[] dllFileNames = null;
             if (Directory.Exists("Plugins"))
@@ -496,7 +501,7 @@ namespace SoluiNet.DevTools.Core.Tools
 
             foreach (var plugin in pluginList)
             {
-                if (plugin.Name.Equals(name, StringComparison.InvariantCulture))
+                if (plugin.Name.Equals(name, StringComparison.Ordinal))
                 {
                     return plugin;
                 }

--- a/SoluiNet.DevTools.SqlPlugin.Example/ExamplePlugin.cs
+++ b/SoluiNet.DevTools.SqlPlugin.Example/ExamplePlugin.cs
@@ -151,7 +151,7 @@ namespace SoluiNet.DevTools.SqlPlugin.Example
                 return DbHelper.ExecuteSqlScript(
                     ConfigurationManager.ConnectionStrings[this.ConnectionStringName].ProviderName,
                     ConfigurationManager.ConnectionStrings[this.ConnectionStringName].ConnectionString,
-                    sqlCommand);
+                    sqlCommand) as List<DataTable>;
             }
             finally
             {

--- a/SoluiNet.DevTools.Transform.Uml/TransformUmlPlugin.cs
+++ b/SoluiNet.DevTools.Transform.Uml/TransformUmlPlugin.cs
@@ -49,6 +49,11 @@ namespace SoluiNet.DevTools.Transform.Uml
         /// <inheritdoc/>
         public object Transform(string inputFile, string preferedOutputFormat)
         {
+            if (preferedOutputFormat == null)
+            {
+                throw new ArgumentNullException(nameof(preferedOutputFormat));
+            }
+
             var extension = Path.GetExtension(inputFile);
 
             object result = null;
@@ -58,7 +63,7 @@ namespace SoluiNet.DevTools.Transform.Uml
                 case "cs":
                     var cSharpTransform = new CSharpTransform(inputFile);
 
-                    if (preferedOutputFormat.Equals("xml"))
+                    if (preferedOutputFormat.Equals("xml", StringComparison.Ordinal))
                     {
                         result = cSharpTransform.TransformToXml();
                     }

--- a/SoluiNet.DevTools.UI.Sql/SqlUiElement.xaml.cs
+++ b/SoluiNet.DevTools.UI.Sql/SqlUiElement.xaml.cs
@@ -92,15 +92,15 @@ namespace SoluiNet.DevTools.UI.Sql
             }
         }
 
-        private string LoggingPath { get; }
-
-        private Logger Logger
+        private static Logger Logger
         {
             get
             {
                 return LogManager.GetCurrentClassLogger();
             }
         }
+
+        private string LoggingPath { get; }
 
         private static void PopulateGridContextMenu(DataGrid dataGrid)
         {
@@ -119,9 +119,7 @@ namespace SoluiNet.DevTools.UI.Sql
 
             copyToClipboardMenuItem.Click += (sender, eventInfo) =>
             {
-                var containingGrid = ((sender as MenuItem)?.Parent as ContextMenu)?.PlacementTarget as DataGrid;
-
-                if (containingGrid == null)
+                if (!(((sender as MenuItem)?.Parent as ContextMenu)?.PlacementTarget is DataGrid containingGrid))
                 {
                     return;
                 }

--- a/SoluiNet.DevTools.UI.Sql/SqlUiElement.xaml.cs
+++ b/SoluiNet.DevTools.UI.Sql/SqlUiElement.xaml.cs
@@ -62,7 +62,7 @@ namespace SoluiNet.DevTools.UI.Sql
                     }
                     catch (Exception exception)
                     {
-                        this.Logger.Error(exception);
+                        SqlUiElement.Logger.Error(exception);
                         throw;
                     }
                 }
@@ -331,7 +331,7 @@ namespace SoluiNet.DevTools.UI.Sql
                 ? this.SqlCommandText.Text
                 : this.SqlCommandText.SelectedText;
 
-            this.Logger.Info(string.Format(CultureInfo.InvariantCulture, "[{1} ({2})] Executing SQL command: {0}", sqlCommand, this.Project.Text, plugin.Environment));
+            SqlUiElement.Logger.Info(string.Format(CultureInfo.InvariantCulture, "[{1} ({2})] Executing SQL command: {0}", sqlCommand, this.Project.Text, plugin.Environment));
 
             var data = plugin.ExecuteSqlScript(sqlCommand);
 
@@ -715,7 +715,7 @@ namespace SoluiNet.DevTools.UI.Sql
                 return;
             }
 
-            this.Logger.Info(string.Format(CultureInfo.InvariantCulture, "[{1} ({2})] Displaying {3}: {0}", databaseElement.Name, plugin.Name, plugin.Environment, type));
+            SqlUiElement.Logger.Info(string.Format(CultureInfo.InvariantCulture, "[{1} ({2})] Displaying {3}: {0}", databaseElement.Name, plugin.Name, plugin.Environment, type));
 
             var dialog = new ShowText
             {

--- a/SoluiNet.DevTools.UI/MainWindow.xaml.cs
+++ b/SoluiNet.DevTools.UI/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace SoluiNet.DevTools.UI
     /// </summary>
     public partial class MainWindow : SoluiNetWindow
     {
-        private readonly GlobalHotKey hotKey = null;
+        private readonly GlobalHotKey hotKey;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MainWindow"/> class.
@@ -142,9 +142,7 @@ namespace SoluiNet.DevTools.UI
             this.LoggingPath = string.Format(CultureInfo.InvariantCulture, "{0}\\{1}", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "SoluiNet.DevTools.UI");
         }
 
-        private string LoggingPath { get; }
-
-        private Logger Logger
+        private static Logger Logger
         {
             get
             {

--- a/SoluiNet.DevTools.UI/MainWindow.xaml.cs
+++ b/SoluiNet.DevTools.UI/MainWindow.xaml.cs
@@ -119,7 +119,7 @@ namespace SoluiNet.DevTools.UI
                     }
                     catch (Exception exception)
                     {
-                        this.Logger.Error(exception);
+                        MainWindow.Logger.Error(exception);
 
                         throw;
                     }
@@ -149,6 +149,8 @@ namespace SoluiNet.DevTools.UI
                 return LogManager.GetCurrentClassLogger();
             }
         }
+
+        public string LoggingPath { get; }
 
         private void FileCloseMenuItem_Click(object sender, RoutedEventArgs e)
         {

--- a/SoluiNet.DevTools.UI/UserControls/ConnectionString.xaml.cs
+++ b/SoluiNet.DevTools.UI/UserControls/ConnectionString.xaml.cs
@@ -7,6 +7,7 @@ namespace SoluiNet.DevTools.UI.UserControls
     using System;
     using System.Collections.Generic;
     using System.Data.SqlClient;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -211,7 +212,7 @@ namespace SoluiNet.DevTools.UI.UserControls
 
                 if (useWindowsAuthenticationMatch.Success)
                 {
-                    useWindowsAuthenticationTextBox.IsChecked = useWindowsAuthenticationMatch.Groups[1].Value == "SSPI" || Convert.ToBoolean(useWindowsAuthenticationMatch.Groups[1].Value);
+                    useWindowsAuthenticationTextBox.IsChecked = useWindowsAuthenticationMatch.Groups[1].Value == "SSPI" || Convert.ToBoolean(useWindowsAuthenticationMatch.Groups[1].Value, CultureInfo.InvariantCulture);
                 }
 
                 this.ContentGrid.Children.Add(useWindowsAuthenticationTextBox);
@@ -232,15 +233,15 @@ namespace SoluiNet.DevTools.UI.UserControls
                 {
                     if (this.ProviderName == "System.Data.SqlClient")
                     {
-                        var connectionStringBuilder = new SqlConnectionStringBuilder();
-
-                        connectionStringBuilder.DataSource = (this.ContentGrid.FindName("Server") as TextBox)?.Text ?? string.Empty;
-                        connectionStringBuilder.InitialCatalog = (this.ContentGrid.FindName("Database") as TextBox)?.Text ?? string.Empty;
-                        connectionStringBuilder.UserID = (this.ContentGrid.FindName("Username") as TextBox)?.Text ?? string.Empty;
-                        connectionStringBuilder.Password = (this.ContentGrid.FindName("Password") as TextBox)?.Text ?? string.Empty;
-                        connectionStringBuilder.IntegratedSecurity = (this.ContentGrid.FindName("UseWindowsSecurity") as CheckBox)?.IsChecked ?? false;
-
-                        connectionStringBuilder.ApplicationName = "SoluiNet.DevTools";
+                        var connectionStringBuilder = new SqlConnectionStringBuilder
+                        {
+                            DataSource = (this.ContentGrid.FindName("Server") as TextBox)?.Text ?? string.Empty,
+                            InitialCatalog = (this.ContentGrid.FindName("Database") as TextBox)?.Text ?? string.Empty,
+                            UserID = (this.ContentGrid.FindName("Username") as TextBox)?.Text ?? string.Empty,
+                            Password = (this.ContentGrid.FindName("Password") as TextBox)?.Text ?? string.Empty,
+                            IntegratedSecurity = (this.ContentGrid.FindName("UseWindowsSecurity") as CheckBox)?.IsChecked ?? false,
+                            ApplicationName = "SoluiNet.DevTools",
+                        };
 
                         this.Value = connectionStringBuilder.ConnectionString;
                     }

--- a/SoluiNet.DevTools.UI/UserControls/ManageConnectionStrings.xaml.cs
+++ b/SoluiNet.DevTools.UI/UserControls/ManageConnectionStrings.xaml.cs
@@ -7,6 +7,7 @@ namespace SoluiNet.DevTools.UI.UserControls
     using System;
     using System.Collections.Generic;
     using System.Configuration;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -40,10 +41,12 @@ namespace SoluiNet.DevTools.UI.UserControls
             {
                 this.MainContent.RowDefinitions.Add(new RowDefinition());
 
-                var connectionStringView = new ConnectionString();
-                connectionStringView.Value = connectionString.ConnectionString;
-                connectionStringView.NameKey = connectionString.Name;
-                connectionStringView.ProviderName = connectionString.ProviderName;
+                var connectionStringView = new ConnectionString
+                {
+                    Value = connectionString.ConnectionString,
+                    NameKey = connectionString.Name,
+                    ProviderName = connectionString.ProviderName,
+                };
 
                 this.MainContent.Children.Add(connectionStringView);
                 Grid.SetRow(connectionStringView, this.MainContent.RowDefinitions.Count - 1);
@@ -85,6 +88,7 @@ namespace SoluiNet.DevTools.UI.UserControls
                 }
 
                 data += string.Format(
+                    CultureInfo.InvariantCulture,
                     @"<add name=""{0}"" connectionString=""{1}"" providerName=""{2}"" />",
                     connectionString.NameKey,
                     connectionString.Value,
@@ -93,7 +97,7 @@ namespace SoluiNet.DevTools.UI.UserControls
 
             data += "</connectionStrings>";
 
-            File.Move("./ConnectionStrings.config", string.Format("./ConnectionStrings.{0:yyyy-MM-ddTHH-mm-ss}.config", DateTime.Now));
+            File.Move("./ConnectionStrings.config", string.Format(CultureInfo.InvariantCulture, "./ConnectionStrings.{0:yyyy-MM-ddTHH-mm-ss}.config", DateTime.Now));
 
             File.WriteAllText("./ConnectionStrings.config", data);
 

--- a/SoluiNet.DevTools.Utils.Certificate/CertificateToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Certificate/CertificateToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Certificate
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new CertificateUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.Clipboard/ClipboardNativeMethods.cs
+++ b/SoluiNet.DevTools.Utils.Clipboard/ClipboardNativeMethods.cs
@@ -12,7 +12,7 @@ namespace SoluiNet.DevTools.Utils.Clipboard
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Provides native methods for clipboard handling. (see https://stackoverflow.com/questions/15333746/clipboardinterop-content-changed-fires-twice)
+    /// Provides native methods for clipboard handling. (see https://stackoverflow.com/questions/15333746/clipboardinterop-content-changed-fires-twice).
     /// </summary>
     public static class ClipboardNativeMethods
     {

--- a/SoluiNet.DevTools.Utils.Clipboard/ClipboardUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.Clipboard/ClipboardUserControl.xaml.cs
@@ -31,7 +31,7 @@ namespace SoluiNet.DevTools.Utils.Clipboard
     /// </summary>
     public partial class ClipboardUserControl : UserControl
     {
-        IntPtr nextClipboardViewer;
+        private IntPtr nextClipboardViewer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClipboardUserControl"/> class.

--- a/SoluiNet.DevTools.Utils.CodeOnTheFly/CodeOnTheFlyTools.cs
+++ b/SoluiNet.DevTools.Utils.CodeOnTheFly/CodeOnTheFlyTools.cs
@@ -34,103 +34,110 @@ namespace SoluiNet.DevTools.Utils.CodeOnTheFly
         public static string RunDynamicCode(string code, bool sourceCodeComplete = false, string executingMethod = "main", string languageProvider = "CSharp", params object[] methodParameters)
         {
             var compiler = CodeDomProvider.CreateProvider(languageProvider);
-            var parameters = new CompilerParameters();
-
-            parameters.ReferencedAssemblies.Add("System.dll");
-
-            var generatedCode = string.Empty;
-
-            if (!sourceCodeComplete)
-            {
-                generatedCode = string.Format(
-                    CultureInfo.InvariantCulture,
-                    @"using System; " +
-                    "namespace DynamicCode {{ " +
-                    "public class DynamicCodeClass {{ " +
-                    "public object main(params object[] parameters) {{ {0} }} }} }}", code);
-            }
-            else
-            {
-                generatedCode = code;
-            }
-
-            parameters.GenerateInMemory = false;
-
-            var compiled = compiler.CompileAssemblyFromSource(parameters, generatedCode);
-
-            if (compiled.Errors.HasErrors)
-            {
-                string errorMessage = string.Empty;
-
-                errorMessage = string.Format("{0} errors during compilation:", compiled.Errors.Count);
-
-                foreach (CompilerError error in compiled.Errors)
-                {
-                    errorMessage += string.Format("\r\nError on line {0}: {1}", error.Line, error.ErrorText);
-                }
-
-                return errorMessage + "\r\n---\r\n" + code.AddLineNumbers();
-            }
-
-            var assembly = compiled.CompiledAssembly;
-
-            object compiledClass = null;
-
-            if (!sourceCodeComplete)
-            {
-                compiledClass = assembly.CreateInstance("DynamicCode.DynamicCodeClass");
-            }
-            else
-            {
-                var firstAssemblyType = assembly.GetTypes().First();
-
-                compiledClass = assembly.CreateInstance(firstAssemblyType.Namespace + "." + firstAssemblyType.Name);
-            }
-
-            if (compiledClass == null)
-            {
-                return "Couldn't load class.";
-            }
-
-            var codeParameters = new object[5];
-            codeParameters[0] = "SampleString 123";
-            codeParameters[1] = 1.23F; // sample float
-            codeParameters[2] = 1234; // sample int
-            codeParameters[3] = (double)1.23; // sample double
-            codeParameters[4] = DateTime.UtcNow; // sample DateTime
-
             try
             {
-                object result = null;
+                var parameters = new CompilerParameters();
+
+                parameters.ReferencedAssemblies.Add("System.dll");
+
+                var generatedCode = string.Empty;
 
                 if (!sourceCodeComplete)
                 {
-                    result = compiledClass.GetType().InvokeMember(executingMethod, BindingFlags.InvokeMethod, null, compiledClass, codeParameters);
+                    generatedCode = string.Format(
+                        CultureInfo.InvariantCulture,
+                        @"using System; " +
+                        "namespace DynamicCode {{ " +
+                        "public class DynamicCodeClass {{ " +
+                        "public object main(params object[] parameters) {{ {0} }} }} }}", code);
                 }
                 else
                 {
-                    result = compiledClass.GetType().InvokeMember(executingMethod, BindingFlags.InvokeMethod, null, compiledClass, methodParameters);
+                    generatedCode = code;
                 }
 
-                if (result != null)
+                parameters.GenerateInMemory = false;
+
+                var compiled = compiler.CompileAssemblyFromSource(parameters, generatedCode);
+
+                if (compiled.Errors.HasErrors)
                 {
-                    if (result.GetType().IsPrimitive)
+                    string errorMessage = string.Empty;
+
+                    errorMessage = string.Format(CultureInfo.InvariantCulture, "{0} errors during compilation:", compiled.Errors.Count);
+
+                    foreach (CompilerError error in compiled.Errors)
                     {
-                        return string.Format("Result ({0}):\r\n{1}", result.GetType().Name, result.ToString());
+                        errorMessage += string.Format(CultureInfo.InvariantCulture, "\r\nError on line {0}: {1}", error.Line, error.ErrorText);
+                    }
+
+                    return errorMessage + "\r\n---\r\n" + code.AddLineNumbers();
+                }
+
+                var assembly = compiled.CompiledAssembly;
+
+                object compiledClass = null;
+
+                if (!sourceCodeComplete)
+                {
+                    compiledClass = assembly.CreateInstance("DynamicCode.DynamicCodeClass");
+                }
+                else
+                {
+                    var firstAssemblyType = assembly.GetTypes().First();
+
+                    compiledClass = assembly.CreateInstance(firstAssemblyType.Namespace + "." + firstAssemblyType.Name);
+                }
+
+                if (compiledClass == null)
+                {
+                    return "Couldn't load class.";
+                }
+
+                var codeParameters = new object[5];
+                codeParameters[0] = "SampleString 123";
+                codeParameters[1] = 1.23F; // sample float
+                codeParameters[2] = 1234; // sample int
+                codeParameters[3] = (double)1.23; // sample double
+                codeParameters[4] = DateTime.UtcNow; // sample DateTime
+
+                try
+                {
+                    object result = null;
+
+                    if (!sourceCodeComplete)
+                    {
+                        result = compiledClass.GetType().InvokeMember(executingMethod, BindingFlags.InvokeMethod, null, compiledClass, codeParameters, CultureInfo.CurrentCulture);
                     }
                     else
                     {
-                        return string.Format("Result ({0}):\r\n{1}", result.GetType().Name, JsonConvert.SerializeObject(result));
+                        result = compiledClass.GetType().InvokeMember(executingMethod, BindingFlags.InvokeMethod, null, compiledClass, methodParameters, CultureInfo.CurrentCulture);
+                    }
+
+                    if (result != null)
+                    {
+                        if (result.GetType().IsPrimitive)
+                        {
+                            return string.Format(CultureInfo.CurrentCulture, "Result ({0}):\r\n{1}", result.GetType().Name, result.ToString());
+                        }
+                        else
+                        {
+                            return string.Format(CultureInfo.CurrentCulture, "Result ({0}):\r\n{1}", result.GetType().Name, JsonConvert.SerializeObject(result));
+                        }
+                    }
+                    else
+                    {
+                        return "No result received";
                     }
                 }
-                else
+                catch (Exception exception)
                 {
-                    return "No result received";
+                    return exception.Message;
                 }
             }
-            catch (Exception exception)
+            finally
             {
-                return exception.Message;
+                compiler.Dispose();
             }
         }
     }

--- a/SoluiNet.DevTools.Utils.CodeOnTheFly/CodeOnTheFlyToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.CodeOnTheFly/CodeOnTheFlyToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.CodeOnTheFly
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new CodeOnTheFlyUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.Crypto/CryptoTools.cs
+++ b/SoluiNet.DevTools.Utils.Crypto/CryptoTools.cs
@@ -16,7 +16,7 @@ namespace SoluiNet.DevTools.Utils.Crypto
     /// <summary>
     /// Provides a collection of methods for cryptography and hashing.
     /// </summary>
-    public class CryptoTools
+    public static class CryptoTools
     {
         /// <summary>
         /// Encrypt a plain text.
@@ -97,10 +97,7 @@ namespace SoluiNet.DevTools.Utils.Crypto
                             }
                             finally
                             {
-                                if (md5 != null)
-                                {
-                                    md5.Dispose();
-                                }
+                                md5.Dispose();
                             }
 
                             break;
@@ -118,10 +115,7 @@ namespace SoluiNet.DevTools.Utils.Crypto
                             }
                             finally
                             {
-                                if (sha1 != null)
-                                {
-                                    sha1.Dispose();
-                                }
+                                sha1.Dispose();
                             }
 
                             break;
@@ -140,10 +134,7 @@ namespace SoluiNet.DevTools.Utils.Crypto
                             }
                             finally
                             {
-                                if (sha2 != null)
-                                {
-                                    sha2.Dispose();
-                                }
+                                sha2.Dispose();
                             }
 
                             break;

--- a/SoluiNet.DevTools.Utils.Crypto/CryptoToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Crypto/CryptoToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Crypto
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new CryptoToolsUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.Crypto/Utilities/AesUtils.cs
+++ b/SoluiNet.DevTools.Utils.Crypto/Utilities/AesUtils.cs
@@ -24,6 +24,7 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <param name="key">The key.</param>
         /// <param name="initializationValue">The initialization value.</param>
         /// <returns>Returns an encrypted text.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5401:Do not use CreateEncryptor with non-default IV", Justification = "Initialization Value has to be overgivable")]
         public static string Encrypt(string plainText, string key, string initializationValue)
         {
             var bytesToEncrypt = Encoding.UTF8.GetBytes(plainText);
@@ -57,6 +58,7 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <param name="key">The key.</param>
         /// <param name="initializationValue">The initialization value.</param>
         /// <returns>Returns an encrypted and base64 encoded text.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5401:Do not use CreateEncryptor with non-default IV", Justification = "Initialization Value will be overgiven")]
         public static string EncryptAndBase64Encode(string clearText, string key, string initializationValue)
         {
             var bytesToEncrypt = Encoding.UTF8.GetBytes(clearText);
@@ -133,6 +135,11 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns an encrypted text.</returns>
         public string Encrypt(string plainText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var key = options["key"].ToString();
             var initializationValue = options["iniValue"].ToString();
 
@@ -147,6 +154,11 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns an encrypted and base64 encoded text.</returns>
         public string EncryptAndBase64Encode(string plainText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var key = options["key"].ToString();
             var initializationValue = options["iniValue"].ToString();
 
@@ -161,6 +173,11 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns a decrypted text.</returns>
         public string Decrypt(string encryptedText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var key = options["key"].ToString();
             var initializationValue = options["iniValue"].ToString();
 
@@ -175,6 +192,11 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns a base64 decoded and decrypted text.</returns>
         public string Base64DecodeAndDecrypt(string encryptedText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var key = options["key"].ToString();
             var initializationValue = options["iniValue"].ToString();
 

--- a/SoluiNet.DevTools.Utils.Crypto/Utilities/GeneralUtils.cs
+++ b/SoluiNet.DevTools.Utils.Crypto/Utilities/GeneralUtils.cs
@@ -6,6 +6,7 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Security.Cryptography;
@@ -16,7 +17,7 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
     /// <summary>
     /// Provides a collection of methods for general purposes.
     /// </summary>
-    public class GeneralUtils
+    public static class GeneralUtils
     {
         /// <summary>
         /// A delegate to get a processed byte array.
@@ -34,6 +35,11 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns an encoded string.</returns>
         public static string Encode(byte[] originalByteArray, GetProcessedByteArray getProcessedByteArrayDelegate, string chosenEncoding = "UTF8")
         {
+            if (getProcessedByteArrayDelegate == null)
+            {
+                throw new ArgumentNullException(nameof(getProcessedByteArrayDelegate));
+            }
+
             string result;
 
             switch (chosenEncoding)
@@ -75,10 +81,15 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>The string which represents the byte array.</returns>
         public static string ByteArrayToString(byte[] byteArray)
         {
+            if (byteArray == null)
+            {
+                throw new ArgumentNullException(nameof(byteArray));
+            }
+
             StringBuilder hex = new StringBuilder(byteArray.Length * 2);
             foreach (byte b in byteArray)
             {
-                hex.AppendFormat("{0:x2}", b);
+                hex.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", b);
             }
 
             return hex.ToString();

--- a/SoluiNet.DevTools.Utils.Crypto/Utilities/RsaUtils.cs
+++ b/SoluiNet.DevTools.Utils.Crypto/Utilities/RsaUtils.cs
@@ -126,14 +126,19 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns an encrypted text.</returns>
         public string Encrypt(string plainText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var publicKeyPath = options["PublicKeyPath"].ToString();
 
-            if (publicKeyPath.StartsWith("\""))
+            if (publicKeyPath.StartsWith("\"", StringComparison.InvariantCulture))
             {
                 publicKeyPath = publicKeyPath.Substring(1, publicKeyPath.Length - 1);
             }
 
-            if (publicKeyPath.EndsWith("\""))
+            if (publicKeyPath.EndsWith("\"", StringComparison.InvariantCulture))
             {
                 publicKeyPath = publicKeyPath.Substring(0, publicKeyPath.Length - 1);
             }
@@ -149,14 +154,19 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns an encrypted and base64 encoded text.</returns>
         public string EncryptAndBase64Encode(string plainText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var publicKeyPath = options["PublicKeyPath"].ToString();
 
-            if (publicKeyPath.StartsWith("\""))
+            if (publicKeyPath.StartsWith("\"", StringComparison.InvariantCulture))
             {
                 publicKeyPath = publicKeyPath.Substring(1, publicKeyPath.Length - 1);
             }
 
-            if (publicKeyPath.EndsWith("\""))
+            if (publicKeyPath.EndsWith("\"", StringComparison.InvariantCulture))
             {
                 publicKeyPath = publicKeyPath.Substring(0, publicKeyPath.Length - 1);
             }
@@ -172,14 +182,19 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns a decrypted text.</returns>
         public string Decrypt(string encryptedText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var privateKeyPath = options["PrivateKeyPath"].ToString();
 
-            if (privateKeyPath.StartsWith("\""))
+            if (privateKeyPath.StartsWith("\"", StringComparison.InvariantCulture))
             {
                 privateKeyPath = privateKeyPath.Substring(1, privateKeyPath.Length - 1);
             }
 
-            if (privateKeyPath.EndsWith("\""))
+            if (privateKeyPath.EndsWith("\"", StringComparison.InvariantCulture))
             {
                 privateKeyPath = privateKeyPath.Substring(0, privateKeyPath.Length - 1);
             }
@@ -195,14 +210,19 @@ namespace SoluiNet.DevTools.Utils.Crypto.Utilities
         /// <returns>Returns a base64 decoded and decrypted text.</returns>
         public string Base64DecodeAndDecrypt(string encryptedText, IDictionary<string, object> options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var privateKeyPath = options["PrivateKeyPath"].ToString();
 
-            if (privateKeyPath.StartsWith("\""))
+            if (privateKeyPath.StartsWith("\"", StringComparison.InvariantCulture))
             {
                 privateKeyPath = privateKeyPath.Substring(1, privateKeyPath.Length - 1);
             }
 
-            if (privateKeyPath.EndsWith("\""))
+            if (privateKeyPath.EndsWith("\"", StringComparison.InvariantCulture))
             {
                 privateKeyPath = privateKeyPath.Substring(0, privateKeyPath.Length - 1);
             }

--- a/SoluiNet.DevTools.Utils.File/FileTools.cs
+++ b/SoluiNet.DevTools.Utils.File/FileTools.cs
@@ -6,6 +6,7 @@ namespace SoluiNet.DevTools.Utils.File
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -14,7 +15,7 @@ namespace SoluiNet.DevTools.Utils.File
     /// <summary>
     /// Provides a collection of methods for files.
     /// </summary>
-    public class FileTools
+    public static class FileTools
     {
         /// <summary>
         /// Extract lines which contains the search pattern.
@@ -22,7 +23,7 @@ namespace SoluiNet.DevTools.Utils.File
         /// <param name="filePath">The file path.</param>
         /// <param name="searchPattern">The search pattern.</param>
         /// <returns>Returns every line which contains the search pattern.</returns>
-        public static List<string> ExtractLinesContainingSearchPattern(string filePath, string searchPattern)
+        public static IList<string> ExtractLinesContainingSearchPattern(string filePath, string searchPattern)
         {
             var result = new List<string>();
 
@@ -38,7 +39,7 @@ namespace SoluiNet.DevTools.Utils.File
             }
             catch (Exception exception)
             {
-                result.Add(string.Format("##ERROR## Couldn't extract lines from file {0} - {1} ##ERROR##", filePath, exception.Message));
+                result.Add(string.Format(CultureInfo.InvariantCulture, "##ERROR## Couldn't extract lines from file {0} - {1} ##ERROR##", filePath, exception.Message));
             }
 
             return result;
@@ -50,7 +51,7 @@ namespace SoluiNet.DevTools.Utils.File
         /// <param name="filePath">The file path.</param>
         /// <param name="regExPattern">The RegEx search pattern.</param>
         /// <returns>Returns every line which matches the RegEx search pattern.</returns>
-        public static List<string> ExtractLinesMatchingRegEx(string filePath, string regExPattern)
+        public static IList<string> ExtractLinesMatchingRegEx(string filePath, string regExPattern)
         {
             var result = new List<string>();
             var regEx = new Regex(regExPattern);
@@ -72,16 +73,23 @@ namespace SoluiNet.DevTools.Utils.File
         /// <param name="hashType">The hash type which should be used to calculate the hash.</param>
         /// <param name="filePath">The file path.</param>
         /// <returns>Returns the hash of a file into a string.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms", Justification = "We want to use MD5 here.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "We want to receive the result in lower case.")]
         public static string CalculateChecksum(string hashType, string filePath)
         {
             //// todo: get hash type from enumeration
+
+            if (string.IsNullOrEmpty(hashType))
+            {
+                throw new ArgumentNullException(nameof(hashType));
+            }
 
             if (!System.IO.File.Exists(filePath))
             {
                 return string.Empty;
             }
 
-            if (hashType.ToLowerInvariant() == "md5")
+            if (hashType.ToUpperInvariant() == "MD5")
             {
                 using (var md5 = System.Security.Cryptography.MD5.Create())
                 {

--- a/SoluiNet.DevTools.Utils.File/FileToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.File/FileToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.File
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new FileToolsUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.File/FileToolsUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.File/FileToolsUserControl.xaml.cs
@@ -43,7 +43,7 @@ namespace SoluiNet.DevTools.Utils.File
 
         private delegate string FormatSearchResultLine(string line);
 
-        private Logger Logger
+        private static Logger Logger
         {
             get
             {

--- a/SoluiNet.DevTools.Utils.File/FileToolsUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.File/FileToolsUserControl.xaml.cs
@@ -72,11 +72,11 @@ namespace SoluiNet.DevTools.Utils.File
 
             if (this.IsRegEx.IsChecked ?? false)
             {
-                extractedLines = FileTools.ExtractLinesMatchingRegEx(filePath, searchPattern);
+                extractedLines = FileTools.ExtractLinesMatchingRegEx(filePath, searchPattern) as List<string>;
             }
             else
             {
-                extractedLines = FileTools.ExtractLinesContainingSearchPattern(filePath, searchPattern);
+                extractedLines = FileTools.ExtractLinesContainingSearchPattern(filePath, searchPattern) as List<string>;
             }
 
             var omitPrefix = this.OmitPrefix.IsChecked ?? false;
@@ -158,7 +158,7 @@ namespace SoluiNet.DevTools.Utils.File
             {
                 if (isFolderSet)
                 {
-                    this.Logger.Info(
+                    FileToolsUserControl.Logger.Info(
                         CultureInfo.InvariantCulture,
                         "Search for lines in folder '{0}' (filter: '{2}') with the search pattern '{1}' (RegEx: {3}) and replace pattern '{4}' (Ommit Prefix: {5}, Remove duplicates: {7}, temporary file path. '{6}')",
                         this.FolderPath.Text,
@@ -184,7 +184,7 @@ namespace SoluiNet.DevTools.Utils.File
                 }
                 else if (isFileSet)
                 {
-                    this.Logger.Info(
+                    FileToolsUserControl.Logger.Info(
                         CultureInfo.InvariantCulture,
                         "Search for lines in file '{0}' (filter: '{2}') with the search pattern '{1}' (RegEx: {3}) and replace pattern '{4}' (Ommit Prefix: {5}, temporary file path. '{6}')",
                         this.FilePath.Text,
@@ -266,7 +266,7 @@ namespace SoluiNet.DevTools.Utils.File
                 logFile = File.AppendText(temporaryFilePath);
             }
 
-            this.Logger.Info(
+            FileToolsUserControl.Logger.Info(
                 CultureInfo.InvariantCulture,
                 "Find files with the search pattern '{1}' (RegEx: {2}) in folder '{0}' (temporary file path: '{3}')",
                 this.FolderPath.Text,
@@ -360,7 +360,7 @@ namespace SoluiNet.DevTools.Utils.File
             Regex splitRegex = null;
             var splitCondition = this.SplitCondition.Text;
 
-            this.Logger.Info(
+            FileToolsUserControl.Logger.Info(
                 CultureInfo.InvariantCulture,
                 "Split file '{0}' (Condition: '{1}' - RegEx: {3}) at {2} lines",
                 this.SplitFilePath.Text,

--- a/SoluiNet.DevTools.Utils.Flyway/FlywayPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Flyway/FlywayPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Flyway
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new FlywayUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.General/GeneralTools.cs
+++ b/SoluiNet.DevTools.Utils.General/GeneralTools.cs
@@ -6,6 +6,7 @@ namespace SoluiNet.DevTools.Utils.General
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace SoluiNet.DevTools.Utils.General
     /// <summary>
     /// Provides a collection of methods for general purposes.
     /// </summary>
-    public class GeneralTools
+    public static class GeneralTools
     {
         /// <summary>
         /// Calculate an array of numbers for the overgiven number and base.
@@ -40,7 +41,7 @@ namespace SoluiNet.DevTools.Utils.General
                 var valence = Convert.ToInt64(Math.Pow(baseNumber, i));
 
                 result.Add(originalNumber / valence);
-                originalNumber = originalNumber % valence;
+                originalNumber %= valence;
             }
 
             return result.ToArray();
@@ -55,7 +56,7 @@ namespace SoluiNet.DevTools.Utils.General
         {
             if (number < 10)
             {
-                return number.ToString();
+                return number.ToString(CultureInfo.InvariantCulture);
             }
 
             switch (number)
@@ -84,9 +85,13 @@ namespace SoluiNet.DevTools.Utils.General
         /// <returns>Returns the decimal value as long.</returns>
         public static long GetDecimalValueForHex(string hexValue)
         {
+            if (hexValue == null)
+            {
+                throw new ArgumentNullException(nameof(hexValue));
+            }
+
             hexValue = hexValue.Replace("x", string.Empty);
-            long result = 0;
-            long.TryParse(hexValue, System.Globalization.NumberStyles.HexNumber, null, out result);
+            long.TryParse(hexValue, System.Globalization.NumberStyles.HexNumber, null, out long result);
             return result;
         }
 

--- a/SoluiNet.DevTools.Utils.General/GeneralToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.General/GeneralToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.General
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new GeneralToolsUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.General/GeneralToolsUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.General/GeneralToolsUserControl.xaml.cs
@@ -167,7 +167,7 @@ namespace SoluiNet.DevTools.Utils.General
                     this.AsciiTable.Items.Add(tempArray);
                 }
 
-                asciiRow[i % 16] = this.MapCharToReadableString((char)i);
+                asciiRow[i % 16] = GeneralToolsUserControl.MapCharToReadableString((char)i);
             }
 
             this.AsciiTable.Items.Add(asciiRow);

--- a/SoluiNet.DevTools.Utils.General/GeneralToolsUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.General/GeneralToolsUserControl.xaml.cs
@@ -74,6 +74,11 @@ namespace SoluiNet.DevTools.Utils.General
             }
         }
 
+        private static string MapCharToReadableString(char c)
+        {
+            return ReadableCharacters.ContainsKey(c) ? ReadableCharacters[c] : c.ToString(CultureInfo.InvariantCulture);
+        }
+
         private void Calculate_Click(object sender, RoutedEventArgs e)
         {
             var selectedDirection = (this.Direction.SelectedItem as ComboBoxItem).Content;
@@ -146,11 +151,6 @@ namespace SoluiNet.DevTools.Utils.General
 
                 this.NumberOutput.Text = decimalValue.ToString(CultureInfo.InvariantCulture);
             }
-        }
-
-        private string MapCharToReadableString(char c)
-        {
-            return ReadableCharacters.ContainsKey(c) ? ReadableCharacters[c] : c.ToString(CultureInfo.InvariantCulture);
         }
 
         private void TabControl_Initialized(object sender, EventArgs e)

--- a/SoluiNet.DevTools.Utils.Git/GitToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Git/GitToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Git
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new GitUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.MachineLearning/MachineLearningToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.MachineLearning/MachineLearningToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.MachineLearning
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new MachineLearningUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.ScanImage/ScanImagePlugin.cs
+++ b/SoluiNet.DevTools.Utils.ScanImage/ScanImagePlugin.cs
@@ -39,6 +39,11 @@ namespace SoluiNet.DevTools.Utils.ScanImage
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new ScanImageUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.Svn/SvnToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Svn/SvnToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Svn
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new SvnUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.Tfs/TfsToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.Tfs/TfsToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.Tfs
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new TfsUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.TimeTracking/Entities/TimeTrackingContext.cs
+++ b/SoluiNet.DevTools.Utils.TimeTracking/Entities/TimeTrackingContext.cs
@@ -27,7 +27,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking.Entities
         /// <summary>
         /// A value which indicates if the database has already been created.
         /// </summary>
-        private static bool created = false;
+        private static bool created;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeTrackingContext"/> class.
@@ -111,7 +111,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking.Entities
 
             foreach (Match match in connectionStringRegex.Matches(connectionString))
             {
-                if (match.Groups["key"].Value.ToUpperInvariant().Equals("DATA SOURCE", StringComparison.InvariantCulture))
+                if (match.Groups["key"].Value.Equals("DATA SOURCE", StringComparison.OrdinalIgnoreCase))
                 {
                     filePath = match.Groups["val"].Value;
                 }

--- a/SoluiNet.DevTools.Utils.TimeTracking/TimeTrackingToolsUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.TimeTracking/TimeTrackingToolsUserControl.xaml.cs
@@ -48,7 +48,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking
         /// <summary>
         /// A value which indicates if the overview has already been loaded.
         /// </summary>
-        private bool overviewLoaded = false;
+        private bool overviewLoaded;
 
         /// <summary>
         /// The database context where time tracking will be stored.
@@ -58,7 +58,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking
         /// <summary>
         /// A value which indicates if this instance has been disposed already.
         /// </summary>
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeTrackingToolsUserControl"/> class.
@@ -321,7 +321,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking
                 }
             }
 
-            if ((dropSender as UI.AssignmentTargetExtended).Label.Equals("Distribute evenly", StringComparison.InvariantCulture))
+            if ((dropSender as UI.AssignmentTargetExtended).Label.Equals("Distribute evenly", StringComparison.Ordinal))
             {
                 var assignableCategories = categories.ToList().Where(x => x.DistributeEvenlyTarget.GetValueOrDefault(false));
 
@@ -1475,7 +1475,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking
                     searchValues.Contains(x.Category.CategoryName)).
                     Select(x => new { Category = x.Category.CategoryName, x.Duration, x.UsageTime.StartTime }).
                     ToList().
-                    GroupBy(x => new {x.Category, StartTime = x.StartTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) }).
+                    GroupBy(x => new { x.Category, StartTime = x.StartTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) }).
                     ToList();
 
                 var clipboardContent = string.Empty;

--- a/SoluiNet.DevTools.Utils.TimeTracking/UI/CategorySettings.cs
+++ b/SoluiNet.DevTools.Utils.TimeTracking/UI/CategorySettings.cs
@@ -17,7 +17,7 @@ namespace SoluiNet.DevTools.Utils.TimeTracking.UI
     {
         private readonly Category categoryElement;
 
-        private CheckBox distributeEvenlyTarget = null;
+        private CheckBox distributeEvenlyTarget;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CategorySettings"/> class.

--- a/SoluiNet.DevTools.Utils.VsDevEnv/VisualStudioDevEnvToolsPlugin.cs
+++ b/SoluiNet.DevTools.Utils.VsDevEnv/VisualStudioDevEnvToolsPlugin.cs
@@ -41,6 +41,11 @@ namespace SoluiNet.DevTools.Utils.VsDevEnv
         /// <param name="displayInPluginContainer">The delegate which should be called for displaying the plugin.</param>
         public void Execute(Action<UserControl> displayInPluginContainer)
         {
+            if (displayInPluginContainer == null)
+            {
+                throw new ArgumentNullException(nameof(displayInPluginContainer));
+            }
+
             displayInPluginContainer(new VsDevEnvToolsUserControl());
         }
     }

--- a/SoluiNet.DevTools.Utils.WebClient/WebClientTools.cs
+++ b/SoluiNet.DevTools.Utils.WebClient/WebClientTools.cs
@@ -25,6 +25,16 @@ namespace SoluiNet.DevTools.Utils.WebClient
         /// <param name="webRequest">The web request.</param>
         public static void InsertSoapEnvelope(XmlDocument soapEnvelope, HttpWebRequest webRequest)
         {
+            if (webRequest == null)
+            {
+                throw new ArgumentNullException(nameof(webRequest));
+            }
+
+            if (soapEnvelope == null)
+            {
+                throw new ArgumentNullException(nameof(soapEnvelope));
+            }
+
             using (var stream = webRequest.GetRequestStream())
             {
                 soapEnvelope.Save(stream);

--- a/SoluiNet.DevTools.Utils.WebClient/WebClientUserControl.xaml.cs
+++ b/SoluiNet.DevTools.Utils.WebClient/WebClientUserControl.xaml.cs
@@ -178,7 +178,7 @@ namespace SoluiNet.DevTools.Utils.WebClient
 
                 using (var response = request.EndGetResponse(asyncResult))
                 {
-                    var sslProtocols = this.ExtractSslProtocol(response.GetResponseStream());
+                    var sslProtocols = WebClientUserControl.ExtractSslProtocol(response.GetResponseStream());
 
                     if (sslProtocols >= SslProtocols.Tls12)
                     {
@@ -286,7 +286,7 @@ namespace SoluiNet.DevTools.Utils.WebClient
             var window = new Window
             {
                 Title = "Select Web Method from plugin list",
-                Content = new WebClientPluginSelection(plugins)
+                Content = new WebClientPluginSelection(plugins as List<ISupportsWebClient>)
                 {
                     ReturnChosenMethod = (endpoints, content, methods, contentTypes, options, chosenPlugin) =>
                     {

--- a/SoluiNet.DevTools.Utils.XmlTransformation/XmlTools.cs
+++ b/SoluiNet.DevTools.Utils.XmlTransformation/XmlTools.cs
@@ -6,6 +6,7 @@ namespace SoluiNet.DevTools.Utils.XmlTransformation
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -18,7 +19,7 @@ namespace SoluiNet.DevTools.Utils.XmlTransformation
     /// <summary>
     /// Provides a collection of methods for XML.
     /// </summary>
-    public class XmlTools
+    public static class XmlTools
     {
         /// <summary>
         /// Format the overgiven XML string
@@ -73,12 +74,15 @@ namespace SoluiNet.DevTools.Utils.XmlTransformation
             var xsdSchemas = new XmlSchemaSet();
             xsdSchemas.Add(xmlSchema);
 
-            var settings = new XmlReaderSettings();
-            settings.ValidationType = ValidationType.Schema;
-            settings.Schemas = xsdSchemas;
-            settings.ValidationFlags =
+            var settings = new XmlReaderSettings
+            {
+                ValidationType = ValidationType.Schema,
+                Schemas = xsdSchemas,
+                ValidationFlags =
                 XmlSchemaValidationFlags.ProcessIdentityConstraints |
-                XmlSchemaValidationFlags.ReportValidationWarnings;
+                XmlSchemaValidationFlags.ReportValidationWarnings,
+            };
+
             settings.ValidationEventHandler += (validationSender, eventArg) =>
             {
                 if (eventArg.Severity == XmlSeverityType.Warning)
@@ -104,7 +108,7 @@ namespace SoluiNet.DevTools.Utils.XmlTransformation
             }
             catch (XmlException xmlException)
             {
-                result += string.Format("XML-Exception: {0}", xmlException.Message + "\r\n" + xmlException.InnerException?.Message);
+                result += string.Format(CultureInfo.InvariantCulture, "XML-Exception: {0}", xmlException.Message + "\r\n" + xmlException.InnerException?.Message);
             }
 
             return result;

--- a/SoluiNet.DevTools.Web/SimpleWebServer.cs
+++ b/SoluiNet.DevTools.Web/SimpleWebServer.cs
@@ -36,7 +36,7 @@ namespace SoluiNet.DevTools.Web
             // "http://localhost:8080/index/".
             if (prefixes == null || prefixes.Length == 0)
             {
-                throw new ArgumentException("prefixes");
+                throw new ArgumentException(nameof(prefixes));
             }
 
             foreach (string s in prefixes)
@@ -44,7 +44,7 @@ namespace SoluiNet.DevTools.Web
                 this.listener.Prefixes.Add(s);
             }
 
-            this.responderMethod = method ?? throw new ArgumentException("method");
+            this.responderMethod = method ?? throw new ArgumentNullException(nameof(method));
             this.listener.Start();
         }
 
@@ -113,7 +113,8 @@ namespace SoluiNet.DevTools.Web
         /// </summary>
         public void Dispose()
         {
-            ((IDisposable)this.listener)?.Dispose();
+            this.Dispose(true);
+            GC.SuppressFinalize(this);  // Violates rule
         }
 
         /// <summary>
@@ -123,6 +124,21 @@ namespace SoluiNet.DevTools.Web
         {
             this.listener.Stop();
             this.listener.Close();
+        }
+
+        /// <summary>
+        /// Dispose the SimpleWebServer instance.
+        /// </summary>
+        /// <param name="disposing">A value indicating whether the object is being disposed.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.listener != null)
+                {
+                    ((IDisposable)this.listener).Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
CA1816 - improve disposing
CA1309 - use ordinal comparison to improve speed
CA1002 - use interface for collections instead of explicit type
CA5401 - clarify why initalization value will be set by parameters
CA5351, CA5398, CA5386 - clarify why specific SSL protocols have been used in code
CA1308 - clarify why we use lower case
CA1310 - use string comparison which is culture invariant
CA1305 - use culture invariant casts
CA1822 - make properties static if no instance data has been accessed
CA1805 - remove unnecessary initializations
CA1062 - check if value is null before using it
SA1012 - fix spacing
SA1629 - fix documentation